### PR TITLE
fix for journal.sh

### DIFF
--- a/fix_libs.sh
+++ b/fix_libs.sh
@@ -5,8 +5,9 @@ else
 fi
 
 if [ -f librt.so* ]; then
-	cp *.so* ./backuplibs
 	rm librt.so*
+	cp *.so* ./backuplibs
+	ln -s /usr/lib/librt.so* ./backuplibs
 else
 	echo "No libs found."
 fi


### PR DESCRIPTION
On attempt to start journal.sh, it was giving error:

Traceback (most recent call last):
  File "journal.py", line 5, in <module>
ImportError: /usr/lib/libpthread.so.0: version `GLIBC_PRIVATE' not found (required by ./backuplibs/librt.so.1) [24416] Failed to execute script journal

Now it works, on CachyOS.